### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 $ cd catkin_ws/src
 $ git clone https://github.com/takanotume24/turtlebot3_simulations.git
 $ cd turtlebot3
-$ rosdep -i --from-path .
+$ rosdep install -i --from-path .
 $ catkin build
 $ source ../devel/setup.bash
 $ roslaunch turtlebot3_gazebo turtlebot3_with_realsense_d435


### PR DESCRIPTION
rosdep command missing the install, thus leading to "rosdep: error: Unsupported command .."